### PR TITLE
Add type stubs

### DIFF
--- a/ast_serialize.pyi
+++ b/ast_serialize.pyi
@@ -1,6 +1,8 @@
 from typing import TypedDict, type_check_only
 from typing_extensions import NotRequired, TypeAlias
 
+__all__ = ["parse"]
+
 _TypeIgnores: TypeAlias = list[tuple[int, list[str]]]
 
 @type_check_only


### PR DESCRIPTION
`maturin` will automatically include these to the wheel (including auto-added `py.typed` marker), see https://www.maturin.rs/project_layout.html#adding-python-type-information

I also tested and this works with both mypy and PyCharm.