### PR TITLE
Put type comments in assignment on a correct line

### DIFF
--- a/src/serialize_ast.rs
+++ b/src/serialize_ast.rs
@@ -969,9 +969,10 @@ impl Ser for ast::Stmt {
                 // Clone the type expression to avoid borrow checker issues
                 let type_expr = ser.type_comments.get(&line_number).cloned();
 
-                if let Some(type_expr) = type_expr {
+                if let Some(mut type_expr) = type_expr {
                     // Has type annotation from type comment
                     ser.write_bool(true);
+                    ast::relocate::relocate_expr(&mut type_expr, a.range());
                     serialize_type(ser, &type_expr);
                 } else {
                     // No type annotation


### PR DESCRIPTION
Currently line number for a type from a type comment in assignment is always 1, which is wrong. This fix is not perfect but:
* It is simple
* It fixes a bunch of tests
* It roughly matches old parser logic
* Type comments are things of the past anyway, so we should not be super-precise