### PR TITLE
Add support for top-level type ignore

### DIFF
--- a/src/serialize_ast.rs
+++ b/src/serialize_ast.rs
@@ -234,6 +234,7 @@ pub(crate) fn serialize_python_file(
                         line: first_line,
                         column: 0,
                         message: error,
+                        blocker: false,
                     }
                 )
             }


### PR DESCRIPTION
Having `# type: ignore` at top of file effectively erases whole file, so this is what I do. Note that `fastparse.py` instead marks whole file as unreachable, but this looks like just some redundant work, I don't see any difference in tests.