### PR TITLE
Handle top-level always false asserts

### DIFF
--- a/src/reachability.rs
+++ b/src/reachability.rs
@@ -419,6 +419,15 @@ pub(crate) fn consider_sys_platform(expr: &ast::Expr, options: &Options) -> Trut
     }
 }
 
+/// Infer whether a given statement is an assert that will always fail.
+pub(crate) fn assert_will_always_fail(stmt: &ast::Stmt, options: &Options) -> bool {
+    if let ast::Stmt::Assert(a) = stmt {
+        let truth_value = infer_condition_value(a.test.as_ref(), options);
+        return truth_value == TruthValue::AlwaysFalse || truth_value == TruthValue::MypyFalse;
+    }
+    false
+}
+
 /// Infer whether the given condition is always true/false.
 pub(crate) fn infer_condition_value(
     expr: &ast::Expr,

--- a/src/serialize_ast.rs
+++ b/src/serialize_ast.rs
@@ -12,7 +12,7 @@ use ruff_text_size::{Ranged, TextRange};
 
 use crate::func_effect_visitor;
 use crate::options::Options;
-use crate::reachability::TruthValue;
+use crate::reachability::{assert_will_always_fail, TruthValue};
 use crate::type_comment;
 use crate::type_comment::parse_func_type_comment;
 
@@ -569,8 +569,17 @@ impl Ser for ast::Mod {
     fn serialize(&self, ser: &mut Serializer) {
         match self {
             ast::Mod::Module(m) => {
-                ser.write_tagged_int(m.body.len() as i64);
+                let mut body = Vec::new();
                 for stmt in &m.body {
+                    body.push(stmt);
+                    // This mimics behaviour of old parser; we strip everything
+                    // after a top-level assert that is always false.
+                    if assert_will_always_fail(stmt, &ser.options) {
+                        break
+                    }
+                }
+                ser.write_tagged_int(body.len() as i64);
+                for stmt in body {
                     stmt.serialize(ser);
                 }
             }


### PR DESCRIPTION
This is a part of semantic analysis pass 1 that is currently not handled. I am simply replicating the existing behaviour 1:1.

cc @JukkaL 