### PR TITLE
Add support for t-strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,10 +117,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
-name = "get-size-derive2"
-version = "0.6.3"
+name = "equivalent"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a443e77201a230c25f0c11574e9b20e5705f749520e0f30ab0d0974fb1a794"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "get-size-derive2"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b6d1e2f75c16bfbcd0f95d84f99858a6e2f885c2287d1f5c3a96e8444a34b4"
 dependencies = [
  "attribute-derive",
  "quote",
@@ -129,13 +135,14 @@ dependencies = [
 
 [[package]]
 name = "get-size2"
-version = "0.6.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0594e2a78d082f2f8b1615c728391c6a5277f6c017474a7249934fc735945d55"
+checksum = "49cf31a6d70300cf81461098f7797571362387ef4bf85d32ac47eaa59b3a5a1a"
 dependencies = [
  "compact_str",
  "get-size-derive2",
  "hashbrown",
+ "ordermap",
  "smallvec",
 ]
 
@@ -170,6 +177,16 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indexmap"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "indoc"
@@ -272,6 +289,15 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "ordermap"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfa78c92071bbd3628c22b1a964f7e0eb201dc1456555db072beb1662ecd6715"
+dependencies = [
+ "indexmap",
+]
 
 [[package]]
 name = "phf"
@@ -474,14 +500,13 @@ checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 [[package]]
 name = "ruff_python_ast"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff?tag=0.12.12#c6516e9b60e7b8d3d60b1e3a0fb0db04b533de54"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.5#5e4a3d9c3b381df20f6a52caef0f56ed0ebc74be"
 dependencies = [
  "aho-corasick",
  "bitflags",
  "compact_str",
  "get-size2",
  "is-macro",
- "itertools",
  "memchr",
  "ruff_python_trivia",
  "ruff_source_file",
@@ -493,7 +518,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_parser"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff?tag=0.12.12#c6516e9b60e7b8d3d60b1e3a0fb0db04b533de54"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.5#5e4a3d9c3b381df20f6a52caef0f56ed0ebc74be"
 dependencies = [
  "bitflags",
  "bstr",
@@ -513,7 +538,7 @@ dependencies = [
 [[package]]
 name = "ruff_python_trivia"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff?tag=0.12.12#c6516e9b60e7b8d3d60b1e3a0fb0db04b533de54"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.5#5e4a3d9c3b381df20f6a52caef0f56ed0ebc74be"
 dependencies = [
  "itertools",
  "ruff_source_file",
@@ -524,7 +549,7 @@ dependencies = [
 [[package]]
 name = "ruff_source_file"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff?tag=0.12.12#c6516e9b60e7b8d3d60b1e3a0fb0db04b533de54"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.5#5e4a3d9c3b381df20f6a52caef0f56ed0ebc74be"
 dependencies = [
  "memchr",
  "ruff_text_size",
@@ -533,7 +558,7 @@ dependencies = [
 [[package]]
 name = "ruff_text_size"
 version = "0.0.0"
-source = "git+https://github.com/astral-sh/ruff?tag=0.12.12#c6516e9b60e7b8d3d60b1e3a0fb0db04b533de54"
+source = "git+https://github.com/astral-sh/ruff?tag=0.15.5#5e4a3d9c3b381df20f6a52caef0f56ed0ebc74be"
 dependencies = [
  "get-size2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ crate-type = ["cdylib"]
 pyo3 = { version = "0.28.2", features = ["extension-module"] }
 
 # Ruff dependencies for parsing Python - pinned to release tag
-ruff_python_ast = { git = "https://github.com/astral-sh/ruff", tag = "0.12.12" }
-ruff_python_parser = { git = "https://github.com/astral-sh/ruff", tag = "0.12.12" }
-ruff_source_file = { git = "https://github.com/astral-sh/ruff", tag = "0.12.12" }
-ruff_text_size = { git = "https://github.com/astral-sh/ruff", tag = "0.12.12" }
+ruff_python_ast = { git = "https://github.com/astral-sh/ruff", tag = "0.15.5" }
+ruff_python_parser = { git = "https://github.com/astral-sh/ruff", tag = "0.15.5" }
+ruff_source_file = { git = "https://github.com/astral-sh/ruff", tag = "0.15.5" }
+ruff_text_size = { git = "https://github.com/astral-sh/ruff", tag = "0.15.5" }
 
 # Error handling
 anyhow = "1.0"

--- a/src/serialize_ast.rs
+++ b/src/serialize_ast.rs
@@ -4,9 +4,9 @@ use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 use anyhow::Result;
-use ruff_python_ast::{self as ast, AnyParameterRef, StmtFunctionDef};
-use ruff_python_ast::{Number, PySourceType};
-use ruff_python_parser::{Mode, ParseOptions, parse_unchecked, TokenKind, Tokens};
+use ruff_python_ast::{self as ast, AnyParameterRef, Number, PySourceType, StmtFunctionDef};
+use ruff_python_ast::token::{TokenKind, Tokens};
+use ruff_python_parser::{Mode, ParseOptions, parse_unchecked};
 use ruff_source_file::LineIndex;
 use ruff_text_size::{Ranged, TextRange};
 
@@ -118,6 +118,7 @@ const TAG_TYPE_ALIAS_STMT: u8 = 225;
 const TAG_IMPORT_METADATA: u8 = 226;
 const TAG_IMPORTFROM_METADATA: u8 = 227;
 const TAG_IMPORTALL_METADATA: u8 = 228;
+const TAG_TSTRING_EXPR: u8 = 229;
 const TAG_UNBOUND_TYPE: u8 = 104;
 const TAG_TUPLE_TYPE: u8 = 112;
 const TAG_TYPED_DICT_TYPE: u8 = 113;
@@ -640,7 +641,7 @@ fn first_statement_line(
 /// This function combines the functionality of extract_type_ignore_lines and extract_type_comments
 /// to avoid two separate passes over the token sequence, improving cache locality.
 fn extract_type_comments_and_ignores(
-    tokens: &ruff_python_parser::Tokens,
+    tokens: &Tokens,
     source: &str,
     line_index: &LineIndex,
 ) -> (Vec<(usize, Vec<String>)>, HashMap<usize, ParsedTypeComment>) {
@@ -2248,6 +2249,53 @@ impl Ser for ast::Expr {
                 // Serialize the awaited expression
                 await_expr.value.serialize(ser);
                 ser.write_location(await_expr.range());
+            }
+            ast::Expr::TString(ts) => {
+                ser.write_tag(TAG_TSTRING_EXPR);
+                ser.write_tagged_int(ts.value.elements().count() as i64);
+                for part in ts.value.elements() {
+                    match part {
+                        ast::InterpolatedStringElement::Interpolation(tstring_part) => {
+                            ser.write_bool(true);
+                            tstring_part.expression.serialize(ser);
+                            ser.write_bytes(ser.text[tstring_part.expression.range()].as_bytes());
+                            // This matches how mypy old parser handles conversions, but this is
+                            // inconsistent with f-strings, where we use "!s", not just "s", etc.
+                            match tstring_part.conversion {
+                                ast::ConversionFlag::None => {
+                                    ser.write_bool(false);
+                                }
+                                ast::ConversionFlag::Str => {
+                                    ser.write_bool(true);
+                                    ser.write_bytes(b"s");
+                                }
+                                ast::ConversionFlag::Repr => {
+                                    ser.write_bool(true);
+                                    ser.write_bytes(b"r");
+                                }
+                                ast::ConversionFlag::Ascii => {
+                                    ser.write_bool(true);
+                                    ser.write_bytes(b"a");
+                                }
+                            }
+                            // Reuse f-string logic for format specifiers. This is weird, but this is
+                            // what other parsers do (including Python, ruff, and mypy old parser).
+                            if let Some(format_spec) = &tstring_part.format_spec {
+                                ser.write_bool(true);
+                                serialize_fstring_elements(ser, format_spec.elements.iter().collect());
+                                ser.write_location(format_spec.range());
+                            } else {
+                                ser.write_bool(false);
+                            }
+                        }
+                        ast::InterpolatedStringElement::Literal(lit) => {
+                            ser.write_bool(false);
+                            ser.write_bytes(lit.value.as_bytes());
+                            ser.write_location(lit.range());
+                        }
+                    }
+                }
+                ser.write_location(ts.range());
             }
             _ => {
                 panic!("unsupported: {self:?}");

--- a/src/type_comment.rs
+++ b/src/type_comment.rs
@@ -1,7 +1,8 @@
 //! Parse type comments from Python source code
 
 use ruff_python_parser;
-use ruff_python_parser::{parse_unchecked, Mode, ParseOptions, TokenKind};
+use ruff_python_parser::{parse_unchecked, Mode, ParseOptions};
+use ruff_python_ast::token::{TokenKind};
 use ruff_text_size::Ranged;
 
 /// Individual type comment found in a comment line


### PR DESCRIPTION
Fixes https://github.com/mypyc/ast_serialize/issues/20

The logic is straightforward: bump ruff, and replicate what the old parser does.

cc @JukkaL 