### PR TITLE
Store range for names bound by except handlers

### DIFF
--- a/ast_serialize.pyi
+++ b/ast_serialize.pyi
@@ -27,5 +27,6 @@ def parse(
     platform: str | None = None,
     always_true: list[str] | None = None,
     always_false: list[str] | None = None,
+    cache_version: int = 0,
 ) -> tuple[bytes, list[ParseError], _TypeIgnores, bytes, _ASTData]:
     ...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,8 @@ pub mod type_comment;
     python_version=None,
     platform=None,
     always_true=None,
-    always_false=None
+    always_false=None,
+    cache_version=0
 ))]
 fn parse(
     py: Python,
@@ -50,6 +51,7 @@ fn parse(
     platform: Option<String>,
     always_true: Option<Vec<String>>,
     always_false: Option<Vec<String>>,
+    cache_version: u32,
 ) -> PyResult<(Vec<u8>, Vec<Py<PyAny>>, Vec<Py<PyAny>>, Vec<u8>, Py<PyAny>)> {
     // Get defaults from Python if not provided
     let python_version = match python_version {
@@ -85,7 +87,13 @@ fn parse(
             serialize_ast::serialize_python_file(
                 path,
                 skip_function_bodies,
-                options::Options::new(python_version, platform, always_true, always_false),
+                options::Options::new(
+                    python_version,
+                    platform,
+                    always_true,
+                    always_false,
+                    cache_version,
+                ),
             )
         })
         .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;

--- a/src/options.rs
+++ b/src/options.rs
@@ -4,6 +4,7 @@ pub(crate) struct Options {
     platform: String,
     always_true: Vec<String>,
     always_false: Vec<String>,
+    cache_version: u32,
 }
 
 impl Default for Options {
@@ -13,6 +14,8 @@ impl Default for Options {
             platform: String::from("linux"),
             always_true: Vec::new(),
             always_false: Vec::new(),
+            // Always set to latest supported version.
+            cache_version: 1,
         }
     }
 }
@@ -23,12 +26,14 @@ impl Options {
         platform: String,
         always_true: Vec<String>,
         always_false: Vec<String>,
+        cache_version: u32,
     ) -> Self {
         Self {
             python_version,
             platform,
             always_true,
             always_false,
+            cache_version,
         }
     }
 
@@ -46,5 +51,9 @@ impl Options {
 
     pub(crate) fn always_false(&self) -> &[String] {
         &self.always_false
+    }
+
+    pub(crate) fn cache_version(&self) -> u32 {
+        self.cache_version
     }
 }

--- a/src/reachability.rs
+++ b/src/reachability.rs
@@ -534,7 +534,7 @@ mod tests {
             panic!("Expected expression");
         };
 
-        let options = Options::new((3, 10), String::from("linux"), Vec::new(), Vec::new());
+        let options = Options::new((3, 10), String::from("linux"), Vec::new(), Vec::new(), 0);
         infer_condition_value(&expr_mod.body, &options)
     }
 
@@ -557,6 +557,7 @@ mod tests {
                 String::from("linux"),
                 always_true.to_vec(),
                 always_false.to_vec(),
+                0,
             );
             infer_condition_value(&expr_mod.body, &options)
         };
@@ -610,6 +611,7 @@ mod tests {
                 String::from("linux"),
                 always_true.to_vec(),
                 always_false.to_vec(),
+                0,
             );
             infer_condition_value(&expr_mod.body, &options)
         };
@@ -730,7 +732,7 @@ mod tests {
     #[test]
     fn test_consider_sys_version_info() {
         use ruff_python_parser::{Mode, ParseOptions, parse_unchecked};
-        let options = Options::new((3, 10), String::from("linux"), Vec::new(), Vec::new());
+        let options = Options::new((3, 10), String::from("linux"), Vec::new(), Vec::new(), 0);
 
         let parse_expr = |code: &str| {
             let parsed = parse_unchecked(code, ParseOptions::from(Mode::Expression));
@@ -975,8 +977,8 @@ mod tests {
     #[test]
     fn test_consider_sys_platform() {
         use ruff_python_parser::{Mode, ParseOptions, parse_unchecked};
-        let linux_options = Options::new((3, 10), String::from("linux"), Vec::new(), Vec::new());
-        let win32_options = Options::new((3, 10), String::from("win32"), Vec::new(), Vec::new());
+        let linux_options = Options::new((3, 10), String::from("linux"), Vec::new(), Vec::new(), 0);
+        let win32_options = Options::new((3, 10), String::from("win32"), Vec::new(), Vec::new(), 0);
 
         let parse_expr = |code: &str| {
             let parsed = parse_unchecked(code, ParseOptions::from(Mode::Expression));

--- a/src/serialize_ast.rs
+++ b/src/serialize_ast.rs
@@ -1661,6 +1661,9 @@ impl Ser for ast::Stmt {
                             if let Some(name) = &h.name {
                                 ser.write_bool(true);
                                 ser.write_bytes(name.as_bytes());
+                                if ser.options.cache_version() >= 1 {
+                                    ser.write_location(name.range());
+                                }
                             } else {
                                 ser.write_bool(false);
                             }


### PR DESCRIPTION
Fixes https://github.com/mypyc/ast_serialize/issues/50

I also add `cache_version` argument to do this in a backwards compatible way. I verified all tests pass if I use this PR with mypy unmodified.

cc @JukkaL 