### PR TITLE
Calculate and return source file hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,6 +109,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "derive-where"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +136,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
 ]
 
 [[package]]
@@ -121,6 +159,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "get-size-derive2"
@@ -282,6 +330,7 @@ dependencies = [
  "ruff_python_parser",
  "ruff_source_file",
  "ruff_text_size",
+ "sha1",
 ]
 
 [[package]]
@@ -611,6 +660,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +741,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,6 +788,12 @@ dependencies = [
  "phf_codegen",
  "rand",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,9 @@ ruff_text_size = { git = "https://github.com/astral-sh/ruff", tag = "0.15.5" }
 # Error handling
 anyhow = "1.0"
 
+# Hashing
+sha1 = "0.10"
+
 [dev-dependencies]
 indoc = "2"
 

--- a/ast_serialize.pyi
+++ b/ast_serialize.pyi
@@ -18,6 +18,7 @@ class _ASTData(TypedDict):
     is_partial_package: bool
     uses_template_strings: bool
     mypy_ignores: _TypeIgnores
+    source_hash: str
 
 def parse(
     fnam: str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ fn parse(
         import_bytes,
         is_partial_package,
         uses_template_strings,
+        source_hash,
     ) = py
         .detach(|| {
             serialize_ast::serialize_python_file(
@@ -123,6 +124,7 @@ fn parse(
     ast_data.set_item("is_partial_package", is_partial_package)?;
     ast_data.set_item("mypy_ignores", py_mypy_ignores)?;
     ast_data.set_item("uses_template_strings", uses_template_strings)?;
+    ast_data.set_item("source_hash", source_hash)?;
     let ast_data = ast_data.into();
 
     Ok((

--- a/src/serialize_ast.rs
+++ b/src/serialize_ast.rs
@@ -5,12 +5,12 @@ use std::fmt::Write;
 use std::path::Path;
 
 use anyhow::Result;
-use sha1::{Digest, Sha1};
 use ruff_python_ast::token::{TokenKind, Tokens};
 use ruff_python_ast::{self as ast, AnyParameterRef, Number, PySourceType, StmtFunctionDef};
 use ruff_python_parser::{Mode, ParseOptions, parse_unchecked};
 use ruff_source_file::LineIndex;
 use ruff_text_size::{Ranged, TextRange};
+use sha1::{Digest, Sha1};
 
 use crate::func_effect_visitor;
 use crate::options::Options;

--- a/src/serialize_ast.rs
+++ b/src/serialize_ast.rs
@@ -1,9 +1,11 @@
 //! Serialize the AST for a given Python file as a mypy AST
 
 use std::collections::{HashMap, HashSet};
+use std::fmt::Write;
 use std::path::Path;
 
 use anyhow::Result;
+use sha1::{Digest, Sha1};
 use ruff_python_ast::token::{TokenKind, Tokens};
 use ruff_python_ast::{self as ast, AnyParameterRef, Number, PySourceType, StmtFunctionDef};
 use ruff_python_parser::{Mode, ParseOptions, parse_unchecked};
@@ -186,9 +188,20 @@ pub(crate) fn serialize_python_file(
     Vec<u8>,
     bool,
     bool,
+    String,
 )> {
     let source_type = PySourceType::from(file_path);
     let source_text = std::fs::read_to_string(file_path)?;
+
+    // Compute SHA1 hash of the source text (same as mypy's compute_hash)
+    let hash_hex = {
+        let hash = Sha1::digest(source_text.as_bytes());
+        let mut hex = String::with_capacity(40);
+        for byte in hash {
+            write!(hex, "{byte:02x}").unwrap();
+        }
+        hex
+    };
     let line_index = LineIndex::from_source_text(&source_text);
     let is_stub_package = match file_path.file_name() {
         Some(file) => file.as_encoded_bytes() == b"__init__.pyi",
@@ -305,6 +318,7 @@ pub(crate) fn serialize_python_file(
         import_bytes,
         is_partial_package,
         ser.uses_template_strings,
+        hash_hex,
     ))
 }
 
@@ -3546,5 +3560,22 @@ mod tests {
         ];
 
         assert_eq!(bytes, expected);
+    }
+
+    #[test]
+    fn test_source_hash() {
+        let source = "x = 1\n";
+        let path = std::env::temp_dir().join(format!(
+            "test_source_hash_{}.py",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::write(&path, source).unwrap();
+        let result = serialize_python_file(&path, false, Options::default()).unwrap();
+        let _ = std::fs::remove_file(&path);
+        let hash_hex = &result.7;
+        assert_eq!(hash_hex, "e139f73e34322031189110afc1939eb1877a8954");
     }
 }


### PR DESCRIPTION
Currently file hash is calculated sequentially in mypy, which limits parallelism during parsing. By doing it in `ast_serialize`, we can speed up the parsing pass later.