### PR TITLE
Find and return "# mypy: ..." config override comments

### DIFF
--- a/ast_serialize.pyi
+++ b/ast_serialize.pyi
@@ -19,6 +19,7 @@ class _ASTData(TypedDict):
     uses_template_strings: bool
     mypy_ignores: _TypeIgnores
     source_hash: str
+    mypy_comments: list[tuple[int, str]]
 
 def parse(
     fnam: str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@ fn parse(
         is_partial_package,
         uses_template_strings,
         source_hash,
+        mypy_comments,
     ) = py
         .detach(|| {
             serialize_ast::serialize_python_file(
@@ -125,6 +126,20 @@ fn parse(
     ast_data.set_item("mypy_ignores", py_mypy_ignores)?;
     ast_data.set_item("uses_template_strings", uses_template_strings)?;
     ast_data.set_item("source_hash", source_hash)?;
+    let py_mypy_comments: PyResult<Vec<Py<PyAny>>> = mypy_comments
+        .iter()
+        .map(|(line, text)| {
+            let tuple = PyTuple::new(
+                py,
+                [
+                    line.into_pyobject(py)?.into_any(),
+                    text.into_pyobject(py)?.into_any(),
+                ],
+            )?;
+            Ok(tuple.into())
+        })
+        .collect();
+    ast_data.set_item("mypy_comments", py_mypy_comments?)?;
     let ast_data = ast_data.into();
 
     Ok((

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ use pyo3::types::{PyDict, PyTuple};
 use std::path::Path;
 
 mod func_effect_visitor;
+mod mypy_inline_config;
 mod options;
 pub mod reachability;
 mod serialize_ast;

--- a/src/mypy_inline_config.rs
+++ b/src/mypy_inline_config.rs
@@ -68,7 +68,9 @@ pub(crate) fn parse_single_mypy_comment(text: &str) -> InlineConfigOverrides {
                 }
             }
             "ignore_errors" => {
-                result.ignore_errors = Some(parse_bool(&value));
+                if let Some(b) = parse_bool(&value) {
+                    result.ignore_errors = Some(b);
+                }
             }
             _ => {}
         }
@@ -131,11 +133,13 @@ fn split_commas(s: &str) -> Vec<String> {
 }
 
 /// Parse a boolean value the way configparser does.
-fn parse_bool(s: &str) -> bool {
-    matches!(
-        s.to_lowercase().as_str(),
-        "1" | "yes" | "true" | "on"
-    )
+/// Returns None for values not recognized by configparser.
+fn parse_bool(s: &str) -> Option<bool> {
+    match s.to_lowercase().as_str() {
+        "1" | "yes" | "true" | "on" => Some(true),
+        "0" | "no" | "false" | "off" => Some(false),
+        _ => None,
+    }
 }
 
 #[cfg(test)]
@@ -262,8 +266,18 @@ mod tests {
             Some(false)
         );
         assert_eq!(
+            parse_single_mypy_comment("ignore-errors=off").ignore_errors,
+            Some(false)
+        );
+        assert_eq!(
             parse_single_mypy_comment("ignore-errors=false").ignore_errors,
             Some(false)
+        );
+        // Unrecognized values are ignored (None), matching configparser
+        // which would raise ValueError — Python side handles the error.
+        assert_eq!(
+            parse_single_mypy_comment("ignore-errors=maybe").ignore_errors,
+            None
         );
     }
 

--- a/src/mypy_inline_config.rs
+++ b/src/mypy_inline_config.rs
@@ -1,0 +1,278 @@
+/// Lightweight parsing of `# mypy: ...` inline configuration comments.
+///
+/// This only extracts the options that affect AST parsing/serialization:
+/// - `always_true` / `always-true`: names treated as always true in reachability
+/// - `always_false` / `always-false`: names treated as always false in reachability
+/// - `ignore_errors` / `ignore-errors`: skip function bodies
+///
+/// The full comment text is still returned to Python for complete config processing.
+
+/// Overrides extracted from a single `# mypy:` comment that affect parsing.
+#[derive(Debug, Default, PartialEq)]
+pub(crate) struct InlineConfigOverrides {
+    pub always_true: Vec<String>,
+    pub always_false: Vec<String>,
+    pub ignore_errors: Option<bool>,
+}
+
+impl InlineConfigOverrides {
+    /// Merge another set of overrides into this one (later comments win for
+    /// `ignore_errors`; list values are extended).
+    pub(crate) fn merge(&mut self, other: InlineConfigOverrides) {
+        self.always_true.extend(other.always_true);
+        self.always_false.extend(other.always_false);
+        if other.ignore_errors.is_some() {
+            self.ignore_errors = other.ignore_errors;
+        }
+    }
+}
+
+/// Parse a single `# mypy:` comment text (the part after `# mypy:`) and extract
+/// overrides for options that affect parsing.
+///
+/// The format follows mypy's `split_directive` + `mypy_comments_to_config_map`:
+/// - Comma-separated entries
+/// - Each entry is `key=value` or bare `key` (bare key means `True`)
+/// - Quoted values preserve commas: `always-true="FOO, BAR"`
+/// - Dashes in keys are normalized to underscores
+///
+/// Only `always_true`, `always_false`, and `ignore_errors` are extracted;
+/// all other options are silently ignored.
+pub(crate) fn parse_single_mypy_comment(text: &str) -> InlineConfigOverrides {
+    let mut result = InlineConfigOverrides::default();
+
+    for (key, value) in split_directive(text) {
+        let normalized = key.replace('-', "_");
+        match normalized.as_str() {
+            "always_true" => {
+                for name in split_commas(&value) {
+                    if !name.is_empty() {
+                        result.always_true.push(name);
+                    }
+                }
+            }
+            "always_false" => {
+                for name in split_commas(&value) {
+                    if !name.is_empty() {
+                        result.always_false.push(name);
+                    }
+                }
+            }
+            "ignore_errors" => {
+                result.ignore_errors = Some(parse_bool(&value));
+            }
+            _ => {}
+        }
+    }
+
+    result
+}
+
+/// Split a directive string on commas, respecting double-quoted sections.
+/// Returns `(key, value)` pairs where bare keys get value `"True"`.
+fn split_directive(s: &str) -> Vec<(String, String)> {
+    let parts = split_respecting_quotes(s);
+    parts
+        .into_iter()
+        .filter_map(|part| {
+            let trimmed = part.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+            if let Some((key, value)) = trimmed.split_once('=') {
+                Some((key.trim().to_string(), value.trim().to_string()))
+            } else {
+                Some((trimmed.to_string(), "True".to_string()))
+            }
+        })
+        .collect()
+}
+
+/// Split `s` on commas, but preserve commas inside double quotes.
+fn split_respecting_quotes(s: &str) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut current = String::new();
+    let mut chars = s.chars();
+
+    while let Some(c) = chars.next() {
+        match c {
+            ',' => {
+                parts.push(current);
+                current = String::new();
+            }
+            '"' => {
+                // Consume until closing quote
+                for c2 in chars.by_ref() {
+                    if c2 == '"' {
+                        break;
+                    }
+                    current.push(c2);
+                }
+            }
+            _ => current.push(c),
+        }
+    }
+    parts.push(current);
+    parts
+}
+
+/// Split a value string on commas (for list-type options like `always_true`).
+fn split_commas(s: &str) -> Vec<String> {
+    s.split(',').map(|part| part.trim().to_string()).collect()
+}
+
+/// Parse a boolean value the way configparser does.
+fn parse_bool(s: &str) -> bool {
+    matches!(
+        s.to_lowercase().as_str(),
+        "1" | "yes" | "true" | "on"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_comment() {
+        let result = parse_single_mypy_comment("");
+        assert_eq!(result, InlineConfigOverrides::default());
+    }
+
+    #[test]
+    fn test_irrelevant_options() {
+        let result = parse_single_mypy_comment("disallow-untyped-defs, warn-return-any");
+        assert_eq!(result, InlineConfigOverrides::default());
+    }
+
+    #[test]
+    fn test_always_true_single() {
+        let result = parse_single_mypy_comment("always-true=MYPY");
+        assert_eq!(result.always_true, vec!["MYPY"]);
+        assert!(result.always_false.is_empty());
+        assert_eq!(result.ignore_errors, None);
+    }
+
+    #[test]
+    fn test_always_false_single() {
+        let result = parse_single_mypy_comment("always-false=SLOW_PATH");
+        assert!(result.always_true.is_empty());
+        assert_eq!(result.always_false, vec!["SLOW_PATH"]);
+    }
+
+    #[test]
+    fn test_always_true_multiple_quoted() {
+        let result = parse_single_mypy_comment("always-true=\"FOO, BAR\"");
+        assert_eq!(result.always_true, vec!["FOO", "BAR"]);
+    }
+
+    #[test]
+    fn test_always_true_and_false() {
+        let result = parse_single_mypy_comment("always-true=FAST, always-false=SLOW");
+        assert_eq!(result.always_true, vec!["FAST"]);
+        assert_eq!(result.always_false, vec!["SLOW"]);
+    }
+
+    #[test]
+    fn test_ignore_errors_bare() {
+        let result = parse_single_mypy_comment("ignore-errors");
+        assert_eq!(result.ignore_errors, Some(true));
+    }
+
+    #[test]
+    fn test_ignore_errors_explicit_true() {
+        let result = parse_single_mypy_comment("ignore-errors=True");
+        assert_eq!(result.ignore_errors, Some(true));
+    }
+
+    #[test]
+    fn test_ignore_errors_explicit_false() {
+        let result = parse_single_mypy_comment("ignore-errors=False");
+        assert_eq!(result.ignore_errors, Some(false));
+    }
+
+    #[test]
+    fn test_underscore_variant() {
+        let result = parse_single_mypy_comment("always_true=FOO");
+        assert_eq!(result.always_true, vec!["FOO"]);
+    }
+
+    #[test]
+    fn test_mixed_relevant_and_irrelevant() {
+        let result =
+            parse_single_mypy_comment("disallow-untyped-defs, always-true=FLAG, warn-return-any");
+        assert_eq!(result.always_true, vec!["FLAG"]);
+        assert!(result.always_false.is_empty());
+        assert_eq!(result.ignore_errors, None);
+    }
+
+    #[test]
+    fn test_extra_whitespace() {
+        let result = parse_single_mypy_comment("  always-true = FOO ,  always-false = BAR  ");
+        assert_eq!(result.always_true, vec!["FOO"]);
+        assert_eq!(result.always_false, vec!["BAR"]);
+    }
+
+    #[test]
+    fn test_merge_overrides() {
+        let mut first = parse_single_mypy_comment("always-true=A");
+        let second = parse_single_mypy_comment("always-true=B, ignore-errors");
+        first.merge(second);
+        assert_eq!(first.always_true, vec!["A", "B"]);
+        assert_eq!(first.ignore_errors, Some(true));
+    }
+
+    #[test]
+    fn test_merge_ignore_errors_last_wins() {
+        let mut first = parse_single_mypy_comment("ignore-errors=True");
+        let second = parse_single_mypy_comment("ignore-errors=False");
+        first.merge(second);
+        assert_eq!(first.ignore_errors, Some(false));
+    }
+
+    #[test]
+    fn test_bool_parsing_variants() {
+        assert_eq!(
+            parse_single_mypy_comment("ignore-errors=yes").ignore_errors,
+            Some(true)
+        );
+        assert_eq!(
+            parse_single_mypy_comment("ignore-errors=1").ignore_errors,
+            Some(true)
+        );
+        assert_eq!(
+            parse_single_mypy_comment("ignore-errors=on").ignore_errors,
+            Some(true)
+        );
+        assert_eq!(
+            parse_single_mypy_comment("ignore-errors=no").ignore_errors,
+            Some(false)
+        );
+        assert_eq!(
+            parse_single_mypy_comment("ignore-errors=0").ignore_errors,
+            Some(false)
+        );
+        assert_eq!(
+            parse_single_mypy_comment("ignore-errors=false").ignore_errors,
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn test_quoted_value_with_spaces() {
+        let result = parse_single_mypy_comment("always-true=\"FOO , BAR , BAZ\"");
+        assert_eq!(result.always_true, vec!["FOO", "BAR", "BAZ"]);
+    }
+
+    #[test]
+    fn test_split_respecting_quotes_basic() {
+        let parts = split_respecting_quotes("a, b, c");
+        assert_eq!(parts, vec!["a", " b", " c"]);
+    }
+
+    #[test]
+    fn test_split_respecting_quotes_with_quotes() {
+        let parts = split_respecting_quotes("x=\"a, b\", y");
+        assert_eq!(parts, vec!["x=a, b", " y"]);
+    }
+}

--- a/src/mypy_inline_config.rs
+++ b/src/mypy_inline_config.rs
@@ -27,6 +27,15 @@ impl InlineConfigOverrides {
     }
 }
 
+/// Process all `# mypy:` comments and return combined overrides.
+pub(crate) fn resolve_overrides(comments: &[(usize, String)]) -> InlineConfigOverrides {
+    let mut result = InlineConfigOverrides::default();
+    for (_, text) in comments {
+        result.merge(parse_single_mypy_comment(text));
+    }
+    result
+}
+
 /// Parse a single `# mypy:` comment text (the part after `# mypy:`) and extract
 /// overrides for options that affect parsing.
 ///

--- a/src/options.rs
+++ b/src/options.rs
@@ -56,4 +56,12 @@ impl Options {
     pub(crate) fn cache_version(&self) -> u32 {
         self.cache_version
     }
+
+    pub(crate) fn extend_always_true(&mut self, names: Vec<String>) {
+        self.always_true.extend(names);
+    }
+
+    pub(crate) fn extend_always_false(&mut self, names: Vec<String>) {
+        self.always_false.extend(names);
+    }
 }

--- a/src/serialize_ast.rs
+++ b/src/serialize_ast.rs
@@ -178,8 +178,8 @@ const LONG_INT_TRAILER: u8 = 15;
 /// Returns an error if the file cannot be read (but not for syntax errors, which are returned in the tuple)
 pub(crate) fn serialize_python_file(
     file_path: &Path,
-    skip_function_bodies: bool,
-    options: Options,
+    mut skip_function_bodies: bool,
+    mut options: Options,
 ) -> Result<(
     Vec<u8>,
     Vec<SyntaxError>,
@@ -239,6 +239,17 @@ pub(crate) fn serialize_python_file(
     // Extract both type: ignore comments and type annotation comments in a single pass
     let (mut type_ignore_lines, mut mypy_ignore_lines, type_comments, mypy_comments) =
         extract_type_comments_and_ignores(parsed.tokens(), &source_text, &line_index);
+
+    // Apply inline config overrides that affect parsing/serialization.
+    let inline_overrides = crate::mypy_inline_config::resolve_overrides(&mypy_comments);
+    options.extend_always_true(inline_overrides.always_true);
+    options.extend_always_false(inline_overrides.always_false);
+    // Inline ignore-errors can only enable body skipping, not disable it,
+    // since the caller may have set skip_function_bodies based on other
+    // context (e.g. ignore_all from config file section matching).
+    if inline_overrides.ignore_errors == Some(true) {
+        skip_function_bodies = true;
+    }
 
     let mut top_unreachable = false;
     let first_ignore = type_ignore_lines.get(0).cloned();

--- a/src/serialize_ast.rs
+++ b/src/serialize_ast.rs
@@ -3729,17 +3729,68 @@ mod tests {
         assert_eq!(comments, vec![]);
     }
 
+    /// Write source to a temporary .py file and return its path.
+    /// The file is named using `label` and a timestamp to avoid collisions.
+    fn write_temp_py(label: &str, source: &str) -> std::path::PathBuf {
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("{label}_{ts}.py"));
+        std::fs::write(&path, source).unwrap();
+        path
+    }
+
+    #[test]
+    fn test_inline_always_true_affects_serialization() {
+        // Verify that "# mypy: always-true=FLAG" in the source has the same
+        // effect on serialization as passing always_true=["FLAG"] via options.
+        let source_with_comment = indoc::indoc! {"
+            # mypy: always-true=FLAG
+            if FLAG:
+                import a
+            else:
+                import b
+        "};
+        // Same structure but with a plain comment so line numbers match.
+        let source_without_comment = indoc::indoc! {"
+            # just a regular comment
+            if FLAG:
+                import a
+            else:
+                import b
+        "};
+        let path1 = write_temp_py("test_inline_at_1", source_with_comment);
+        let path2 = write_temp_py("test_inline_at_2", source_without_comment);
+
+        // Parse with inline comment, no caller-provided always_true
+        let result_inline =
+            serialize_python_file(&path1, false, Options::default()).unwrap();
+        // Parse without comment, but pass always_true via options
+        let options_with_flag = Options::new(
+            (3, 12),
+            "linux".to_string(),
+            vec!["FLAG".to_string()],
+            vec![],
+            1,
+        );
+        let result_option =
+            serialize_python_file(&path2, false, options_with_flag).unwrap();
+
+        let _ = std::fs::remove_file(&path1);
+        let _ = std::fs::remove_file(&path2);
+
+        // The AST bytes should be identical — the inline comment had the
+        // same effect as the caller-provided option.
+        assert_eq!(result_inline.0, result_option.0, "AST bytes differ");
+        // Import bytes should also match (same unreachability flags).
+        assert_eq!(result_inline.4, result_option.4, "import bytes differ");
+    }
+
     #[test]
     fn test_source_hash() {
         let source = "x = 1\n";
-        let path = std::env::temp_dir().join(format!(
-            "test_source_hash_{}.py",
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_nanos()
-        ));
-        std::fs::write(&path, source).unwrap();
+        let path = write_temp_py("test_source_hash", source);
         let result = serialize_python_file(&path, false, Options::default()).unwrap();
         let _ = std::fs::remove_file(&path);
         let hash_hex = &result.7;

--- a/src/serialize_ast.rs
+++ b/src/serialize_ast.rs
@@ -781,7 +781,12 @@ fn extract_type_comments_and_ignores(
         }
     }
 
-    (type_ignore_lines, mypy_ignore_lines, type_comments, mypy_comments)
+    (
+        type_ignore_lines,
+        mypy_ignore_lines,
+        type_comments,
+        mypy_comments,
+    )
 }
 
 fn function_comment_to_expr(
@@ -3716,10 +3721,7 @@ mod tests {
         // Config options starting with "ignore" should not be filtered out
         let source = "# mypy: ignore-missing-imports\n";
         let comments = extract_mypy_comments(source);
-        assert_eq!(
-            comments,
-            vec![(1, "ignore-missing-imports".to_string())]
-        );
+        assert_eq!(comments, vec![(1, "ignore-missing-imports".to_string())]);
     }
 
     #[test]
@@ -3764,8 +3766,7 @@ mod tests {
         let path2 = write_temp_py("test_inline_at_2", source_without_comment);
 
         // Parse with inline comment, no caller-provided always_true
-        let result_inline =
-            serialize_python_file(&path1, false, Options::default()).unwrap();
+        let result_inline = serialize_python_file(&path1, false, Options::default()).unwrap();
         // Parse without comment, but pass always_true via options
         let options_with_flag = Options::new(
             (3, 12),
@@ -3774,8 +3775,7 @@ mod tests {
             vec![],
             1,
         );
-        let result_option =
-            serialize_python_file(&path2, false, options_with_flag).unwrap();
+        let result_option = serialize_python_file(&path2, false, options_with_flag).unwrap();
 
         let _ = std::fs::remove_file(&path1);
         let _ = std::fs::remove_file(&path2);

--- a/src/serialize_ast.rs
+++ b/src/serialize_ast.rs
@@ -189,6 +189,7 @@ pub(crate) fn serialize_python_file(
     bool,
     bool,
     String,
+    Vec<(usize, String)>,
 )> {
     let source_type = PySourceType::from(file_path);
     let source_text = std::fs::read_to_string(file_path)?;
@@ -236,7 +237,7 @@ pub(crate) fn serialize_python_file(
         .collect();
 
     // Extract both type: ignore comments and type annotation comments in a single pass
-    let (mut type_ignore_lines, mut mypy_ignore_lines, type_comments) =
+    let (mut type_ignore_lines, mut mypy_ignore_lines, type_comments, mypy_comments) =
         extract_type_comments_and_ignores(parsed.tokens(), &source_text, &line_index);
 
     let mut top_unreachable = false;
@@ -319,6 +320,7 @@ pub(crate) fn serialize_python_file(
         is_partial_package,
         ser.uses_template_strings,
         hash_hex,
+        mypy_comments,
     ))
 }
 
@@ -681,16 +683,35 @@ fn extract_type_comments_and_ignores(
     Vec<(usize, Vec<String>)>,
     Vec<(usize, Vec<String>)>,
     HashMap<usize, ParsedTypeComment>,
+    Vec<(usize, String)>,
 ) {
     let mut type_ignore_lines = Vec::new();
     let mut mypy_ignore_lines = Vec::new();
     let mut type_comments = HashMap::new();
+    let mut mypy_comments = Vec::new();
 
     for token in tokens.iter() {
         if token.kind().is_comment() {
             let comment_text = &source[token.range()];
             let location = line_index.line_column(token.start(), source);
             let line_number = location.line.get();
+
+            // Check for "# mypy: " inline configuration comments at start of line.
+            // Skip "# mypy: ignore" / "# mypy: ignore[...]" which are already
+            // collected in mypy_ignore_lines.
+            if location.column.get() == 1 {
+                if let Some(after_mypy) = comment_text.strip_prefix("# mypy:") {
+                    let trimmed = after_mypy.trim();
+                    if !trimmed.is_empty() {
+                        let is_ignore = trimmed == "ignore"
+                            || trimmed.starts_with("ignore[")
+                            || trimmed.starts_with("ignore ");
+                        if !is_ignore {
+                            mypy_comments.push((line_number, trimmed.to_string()));
+                        }
+                    }
+                }
+            }
 
             if let Some(parts) = type_comment::parse_type_comments(comment_text) {
                 for part in parts {
@@ -749,7 +770,7 @@ fn extract_type_comments_and_ignores(
         }
     }
 
-    (type_ignore_lines, mypy_ignore_lines, type_comments)
+    (type_ignore_lines, mypy_ignore_lines, type_comments, mypy_comments)
 }
 
 fn function_comment_to_expr(
@@ -3601,6 +3622,100 @@ mod tests {
         ];
 
         assert_eq!(bytes, expected);
+    }
+
+    fn extract_mypy_comments(source: &str) -> Vec<(usize, String)> {
+        let parsed = parse_unchecked(source, ParseOptions::from(PySourceType::Python));
+        let line_index = LineIndex::from_source_text(source);
+        let (_, _, _, mypy_comments) =
+            extract_type_comments_and_ignores(parsed.tokens(), source, &line_index);
+        mypy_comments
+    }
+
+    #[test]
+    fn test_mypy_comment_config_override() {
+        let source = indoc::indoc! {"
+            # mypy: disallow-untyped-defs
+            x = 1
+        "};
+        let comments = extract_mypy_comments(source);
+        assert_eq!(comments, vec![(1, "disallow-untyped-defs".to_string())]);
+    }
+
+    #[test]
+    fn test_mypy_comment_multiple() {
+        let source = indoc::indoc! {"
+            # mypy: disallow-untyped-defs
+            x = 1
+            # mypy: warn-return-any
+        "};
+        let comments = extract_mypy_comments(source);
+        assert_eq!(
+            comments,
+            vec![
+                (1, "disallow-untyped-defs".to_string()),
+                (3, "warn-return-any".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_mypy_comment_not_at_start_of_line() {
+        // Inline mypy comments after code should not be picked up
+        let source = "x = 1  # mypy: disallow-untyped-defs\n";
+        let comments = extract_mypy_comments(source);
+        assert_eq!(comments, vec![]);
+    }
+
+    #[test]
+    fn test_mypy_comment_indented() {
+        // Indented mypy comments should not be picked up
+        let source = indoc::indoc! {"
+            if True:
+                # mypy: disallow-untyped-defs
+                pass
+        "};
+        let comments = extract_mypy_comments(source);
+        assert_eq!(comments, vec![]);
+    }
+
+    #[test]
+    fn test_mypy_comment_ignore_not_included() {
+        // "# mypy: ignore" is handled separately via mypy_ignore_lines
+        let source = "# mypy: ignore[attr-defined]\n";
+        let comments = extract_mypy_comments(source);
+        assert_eq!(comments, vec![]);
+
+        let source = "# mypy: ignore\n";
+        let comments = extract_mypy_comments(source);
+        assert_eq!(comments, vec![]);
+
+        // Extra whitespace around "ignore"
+        let source = "# mypy:  ignore \n";
+        let comments = extract_mypy_comments(source);
+        assert_eq!(comments, vec![]);
+
+        let source = "# mypy:   ignore[arg-type]  \n";
+        let comments = extract_mypy_comments(source);
+        assert_eq!(comments, vec![]);
+    }
+
+    #[test]
+    fn test_mypy_comment_ignore_prefix_config() {
+        // Config options starting with "ignore" should not be filtered out
+        let source = "# mypy: ignore-missing-imports\n";
+        let comments = extract_mypy_comments(source);
+        assert_eq!(
+            comments,
+            vec![(1, "ignore-missing-imports".to_string())]
+        );
+    }
+
+    #[test]
+    fn test_mypy_comment_none() {
+        let source = "x = 1\n";
+        let comments = extract_mypy_comments(source);
+        assert_eq!(comments, vec![]);
     }
 
     #[test]


### PR DESCRIPTION
Currently mypy has to read the source file to get these, which is a sequential bottleneck during the initial parallel parsing phase.

The semantics are similar to mypy.

Since some config options impact serialization or reachability analysis, we process a subset of supported configuration options in Rust now (`always-true`, `always-false` and `ignore-errors`). We replicate the parsing logic used by Python `configparser` here in Rust (at least as much as is needed to process these options).

This doesn't handle the case where outside caller requests errors to be ignored, but the inline override disables error ignores. To properly support this, we'd need to change the public API, as right now we can't know the reason why errors were ignored originally, so we can't tell if `ignore-errors=False` should override this. Currently we just ignore this (it's likely very rare), but I'll create a follow-up issue about this.

We might want to process all config overrides purely in Rust in the future once the legacy parser has been dropped.