### PR TITLE
Build riscv64 wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -32,6 +32,8 @@ jobs:
             target: s390x
           - runner: ubuntu-22.04
             target: ppc64le
+          - runner: ubuntu-24.04
+            target: riscv64
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6


### PR DESCRIPTION
Will be built under ghcr.io/rust-cross/manylinux_2_31-cross:riscv64 container by maturin-action

References:
- https://github.com/PyO3/maturin-action/blob/v1.51.0/README.md?plain=1#L82

Closes #64