### PR TITLE
Build wheels for Python 3.15

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -43,14 +43,14 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.14
+          args: --release --out dist -i python3.14 -i python3.15
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: auto
       - name: Build free-threaded wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.14t
+          args: --release --out dist -i python3.14t -i python3.15t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: auto
       - name: Upload wheels
@@ -81,14 +81,14 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.14
+          args: --release --out dist -i python3.14 -i python3.15
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: musllinux_1_2
       - name: Build free-threaded wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.14t
+          args: --release --out dist -i python3.14t -i python3.15t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: musllinux_1_2
       - name: Upload wheels
@@ -181,7 +181,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.14t
+          args: --release --out dist -i python3.14t -i python3.15t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - name: Upload wheels
         uses: actions/upload-artifact@v5
@@ -215,7 +215,7 @@ jobs:
           MATURIN_PYEMSCRIPTEN_PLATFORM_VERSION: ${{ steps.pyodide-config.outputs.pyodide-abi-version }}
         with:
           target: wasm32-unknown-emscripten
-          args: --release --out dist -i python3.14
+          args: --release --out dist -i python3.14 -i python3.15
           rust-toolchain: ${{ steps.pyodide-config.outputs.rust-toolchain }}
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - name: Upload wheels

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -39,18 +39,25 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: 3.14
-      - name: Build wheels
+      - name: Build abi3 wheel
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.14 -i python3.15
+          args: --release --out dist -i python3.14
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: auto
-      - name: Build free-threaded wheels
+      - name: Build CPython 3.14t wheel
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.14t -i python3.15t
+          args: --release --out dist -i python3.14t
+          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+          manylinux: auto
+      - name: Build abi3t wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist -i python3.15t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: auto
       - name: Upload wheels
@@ -77,18 +84,25 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: 3.14
-      - name: Build wheels
+      - name: Build abi3 wheel
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.14 -i python3.15
+          args: --release --out dist -i python3.14
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: musllinux_1_2
-      - name: Build free-threaded wheels
+      - name: Build CPython 3.14t wheel
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.14t -i python3.15t
+          args: --release --out dist -i python3.14t
+          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+          manylinux: musllinux_1_2
+      - name: Build abi3t wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist -i python3.15t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
           manylinux: musllinux_1_2
       - name: Upload wheels
@@ -115,19 +129,25 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: 3.13
+          python-version: 3.14
           architecture: ${{ matrix.platform.python_arch }}
-      - name: Build wheels
+      - name: Build abi3 wheel
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist
+          args: --release --out dist -i python3.14
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-      - name: Build free-threaded wheels
+      - name: Build CPython 3.14t wheel
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.14t -i python3.15t
+          args: --release --out dist -i python3.14t
+          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+      - name: Build abi3t wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist -i python3.15t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - name: Upload wheels
         uses: actions/upload-artifact@v5
@@ -148,18 +168,24 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
-          python-version: 3.x
-      - name: Build wheels
+          python-version: 3.14
+      - name: Build abi3 wheel
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist
+          args: --release --out dist -i python3.14
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-      - name: Build free-threaded wheels
+      - name: Build CPython 3.14t wheel
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          args: --release --out dist -i python3.14t -i python3.15t
+          args: --release --out dist -i python3.14t
+          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+      - name: Build abi3t wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist -i python3.15t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - name: Upload wheels
         uses: actions/upload-artifact@v5
@@ -186,14 +212,24 @@ jobs:
         with:
           version: ${{ steps.pyodide-config.outputs.emscripten-version }}
           no-cache: true
-      - name: Build wheels
+      - name: Build CPython 3.14 wheel
         uses: PyO3/maturin-action@v1
         env:
           CARGO_TARGET_WASM32_UNKNOWN_EMSCRIPTEN_RUSTFLAGS: ${{ steps.pyodide-config.outputs.rustflags }}
           MATURIN_PYEMSCRIPTEN_PLATFORM_VERSION: ${{ steps.pyodide-config.outputs.pyodide-abi-version }}
         with:
           target: wasm32-unknown-emscripten
-          args: --release --out dist -i python3.14 -i python3.15
+          args: --release --out dist -i python3.14
+          rust-toolchain: ${{ steps.pyodide-config.outputs.rust-toolchain }}
+          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+      - name: Build abi3t wheel
+        uses: PyO3/maturin-action@v1
+        env:
+          CARGO_TARGET_WASM32_UNKNOWN_EMSCRIPTEN_RUSTFLAGS: ${{ steps.pyodide-config.outputs.rustflags }}
+          MATURIN_PYEMSCRIPTEN_PLATFORM_VERSION: ${{ steps.pyodide-config.outputs.pyodide-abi-version }}
+        with:
+          target: wasm32-unknown-emscripten
+          args: --release --out dist -i python3.15
           rust-toolchain: ${{ steps.pyodide-config.outputs.rust-toolchain }}
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - name: Upload wheels

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -123,33 +123,11 @@ jobs:
           target: ${{ matrix.platform.target }}
           args: --release --out dist
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
-
-      # Use NuGet on windows-arm64 until actions/setup-python/#1307 is fixed.
-      - uses: actions/setup-python@v6
-        if: ${{ matrix.platform.python_arch != 'arm64' }}
-        with:
-          python-version: 3.14t
-          architecture: ${{ matrix.platform.python_arch }}
-
-      - uses: NuGet/setup-nuget@v4
-        if: ${{ matrix.platform.python_arch == 'arm64' }}
-      - shell: pwsh
-        if: ${{ matrix.platform.python_arch == 'arm64' }}
-        run: |
-          $ErrorActionPreference = 'Stop'
-          nuget install pythonarm64-freethreaded -Version 3.14.4 -OutputDirectory $env:RUNNER_TEMP\py -ExcludeVersion
-          $tools = "$env:RUNNER_TEMP\py\pythonarm64-freethreaded\tools"
-          "$tools" >> $env:GITHUB_PATH
-          "$tools\Scripts" >> $env:GITHUB_PATH
-          cmd /c mklink "$tools\python3.exe" "$tools\python.exe"
-          & "$tools\python.exe" -m ensurepip --upgrade
-
       - name: Build free-threaded wheels
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.platform.target }}
-          # Hack until actions/setup-python/#1307 is fixed.
-          args: --release --out dist -i python
+          args: --release --out dist -i python3.14t -i python3.15t
           sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
       - name: Upload wheels
         uses: actions/upload-artifact@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,9 @@ jobs:
           - name: Run smoke tests on Windows with Python 3.14
             python: '3.14'
             os: windows-latest
+          - name: Run smoke tests on Ubuntu with Python 3.15t
+            python: '3.15t'
+            os: ubuntu-24.04-arm
 
     name: ${{ matrix.name }}
     timeout-minutes: 5
@@ -43,6 +46,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
       - run: cargo test
       - run: pip install -U .
       - run: python test_ast_serialize.py

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,9 +423,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.2"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf85e27e86080aafd5a22eae58a162e133a589551542b3e5cee4beb27e54f8e1"
+checksum = "fc153f5fd745cc038b5eed86622125969f8a39834a57bc96beaaf2512b1da729"
 dependencies = [
  "libc",
  "once_cell",
@@ -437,18 +437,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.2"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf94ee265674bf76c09fa430b0e99c26e319c945d96ca0d5a8215f31bf81cf7"
+checksum = "bb77d9aa6d647507b55c69ee714d266d84c526c78ff0bc6dd8757f58591e64d1"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.2"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "491aa5fc66d8059dd44a75f4580a2962c1862a1c2945359db36f6c2818b748dc"
+checksum = "3160087aa5733bce7d9a729f8c55f85a2a53b74742a09613178eeebff0722253"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -456,9 +456,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.2"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d671734e9d7a43449f8480f8b38115df67bef8d21f76837fa75ee7aaa5e52e"
+checksum = "91f9d455db760a9a0b0ddeaac25f1390b8a36ba73dfbda9f127cac6fc340d4d5"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -468,13 +468,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.2"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22faaa1ce6c430a1f71658760497291065e6450d7b5dc2bcf254d49f66ee700a"
+checksum = "e343bcec300ff262f5806a33a4e51b6d097a8a46435f512fcb83e95592581625"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 [dependencies]
 # PyO3 for Python bindings
 # Base features always enabled; abi3-py39 is added via stable-abi feature
-pyo3 = { version = "0.28.2", features = ["extension-module"] }
+pyo3 = { version = "0.29.1", features = ["extension-module"] }
 
 # Ruff dependencies for parsing Python - pinned to release tag
 ruff_python_ast = { git = "https://github.com/astral-sh/ruff", tag = "0.15.12" }
@@ -36,7 +36,8 @@ indoc = "2"
 # Default: stable ABI for regular Python 3.9+
 default = ["stable-abi"]
 # Stable ABI wheels (cp39-abi3) - compatible with Python 3.9+
-stable-abi = ["pyo3/abi3-py39"]
+# Stable ABI wheels free-threaded (cp315-abit3t) - compatible with Python 3.15+
+stable-abi = ["pyo3/abi3-py39", "pyo3/abi3t-py315"]
 # Free-threaded Python wheels (cp313t) - for nogil Python
 free-threaded = []
 # Turn off rayon for profiling


### PR DESCRIPTION
Update pyo3 to 0.29.1 to be able to use the abi3t for Python 3.15+.
https://github.com/PyO3/pyo3/releases#release-v0.29.0

Revert windows hack since https://github.com/actions/setup-python/issues/1307 has been fixed.
Fixes https://github.com/mypyc/ast_serialize/issues/59