### PR TITLE
Add missing Python 3.15 trove classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Programming Language :: Rust",
   "Topic :: Software Development",
   "Typing :: Typed",


### PR DESCRIPTION
Very minor thing that was missed after cp315 abi3.abi3t wheels were added in #71.
