### PR TITLE
Set custom version for vendored crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1120,7 +1120,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "ruff_annotate_snippets"
-version = "0.1.0"
+version = "0.1.0-ast-serialize.0.8.0"
 dependencies = [
  "anstream 1.0.0",
  "anstyle",
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_cache"
-version = "0.0.0"
+version = "0.0.0-ast-serialize.0.8.0"
 dependencies = [
  "filetime",
  "glob",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_macros"
-version = "0.0.0"
+version = "0.0.0-ast-serialize.0.8.0"
 dependencies = [
  "heck",
  "itertools",
@@ -1161,7 +1161,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_python_ast"
-version = "0.0.0"
+version = "0.0.0-ast-serialize.0.8.0"
 dependencies = [
  "aho-corasick",
  "bitflags",
@@ -1184,7 +1184,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_python_parser"
-version = "0.0.0"
+version = "0.0.0-ast-serialize.0.8.0"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -1212,7 +1212,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_python_trivia"
-version = "0.0.0"
+version = "0.0.0-ast-serialize.0.8.0"
 dependencies = [
  "itertools",
  "ruff_source_file",
@@ -1222,7 +1222,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_source_file"
-version = "0.0.0"
+version = "0.0.0-ast-serialize.0.8.0"
 dependencies = [
  "get-size2",
  "memchr",
@@ -1232,7 +1232,7 @@ dependencies = [
 
 [[package]]
 name = "ruff_text_size"
-version = "0.0.0"
+version = "0.0.0-ast-serialize.0.8.0"
 dependencies = [
  "get-size2",
  "schemars",

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ of its third party dependencies). The process of updating the Ruff crates is fol
 1. Clone [Ruff repo](https://github.com/astral-sh/ruff) and checkout the desired tag.
 2. Copy all Ruff crates specified in our `Cargo.toml`.
 3. Copy versions of all `[workspace.dependencies]` from Ruff.
-4. If new third party dependencies are added to Ruff, copy them until `cargo test` passes.
+4. Change the versions of the Ruff crates in their `Cargo.toml` files (eg. `crates/ruff_python_ast/Cargo.toml`) to this format: `<crate-ver>-ast-serialize.<ast-serialize-ver>`, eg. `0.0.0-ast-serialize.0.8.0`.
+5. If new third party dependencies are added to Ruff, copy them until `cargo test` passes.
 
 ## Using Coding Agents
 

--- a/crates/ruff_annotate_snippets/Cargo.toml
+++ b/crates/ruff_annotate_snippets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_annotate_snippets"
-version = "0.1.0"
+version = "0.1.0-ast-serialize.0.8.0"
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_cache/Cargo.toml
+++ b/crates/ruff_cache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_cache"
-version = "0.0.0"
+version = "0.0.0-ast-serialize.0.8.0"
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_macros/Cargo.toml
+++ b/crates/ruff_macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_macros"
-version = "0.0.0"
+version = "0.0.0-ast-serialize.0.8.0"
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_python_ast/Cargo.toml
+++ b/crates/ruff_python_ast/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_python_ast"
-version = "0.0.0"
+version = "0.0.0-ast-serialize.0.8.0"
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_python_parser/Cargo.toml
+++ b/crates/ruff_python_parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_python_parser"
-version = "0.0.0"
+version = "0.0.0-ast-serialize.0.8.0"
 publish = false
 authors = ["Charlie Marsh <charlie.r.marsh@gmail.com>", "RustPython Team"]
 edition = { workspace = true }

--- a/crates/ruff_python_trivia/Cargo.toml
+++ b/crates/ruff_python_trivia/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_python_trivia"
-version = "0.0.0"
+version = "0.0.0-ast-serialize.0.8.0"
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_source_file/Cargo.toml
+++ b/crates/ruff_source_file/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_source_file"
-version = "0.0.0"
+version = "0.0.0-ast-serialize.0.8.0"
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }

--- a/crates/ruff_text_size/Cargo.toml
+++ b/crates/ruff_text_size/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ruff_text_size"
-version = "0.0.0"
+version = "0.0.0-ast-serialize.0.8.0"
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
The internal Ruff crates that are now vendored are not versioned which potentially makes bringing `ast-serialize` as a dependency to projects that already depend on the Ruff crates difficult.

`cargo` will reject multiple sources for the same version of crates but using the Ruff crates from a different source by `ast-serialize`, or the other way around - using the crates from `ast-serialize` by other packages, might not be possible because of incompatibilities between Ruff versions.

To resolve this, use a custom version for the vendored crates: `0.0.0-ast-serialize.0.8.0` so that `ast-serialize` can always be built using them even if there are other Ruff crates available in project dependencies.